### PR TITLE
Improve AEM matrix solve and robustness in WiTNO

### DIFF
--- a/src/pyfastwell/wellflow/wi_tno.py
+++ b/src/pyfastwell/wellflow/wi_tno.py
@@ -1,5 +1,7 @@
 from pywellgeo.well_tree.well_tree_tno import *
 from pywellgeo.well_data.names_constants import Constants
+import numpy as np
+import pandas as pd
 
 class WiTNO:
     '''
@@ -10,7 +12,7 @@ class WiTNO:
 
     def __init__ (self, inj: WellTreeTNO, prod: WellTreeTNO, ztop, zbottom,
                   kx, ky, kz, muinj=1e-3, muprod=1e-3, restrictbranch=None, segmentlength=100, verbose=False):
-        """"
+        """
         initialize the well index calculation object
 
         Parameters:
@@ -160,7 +162,6 @@ class WiTNO:
         delta = (self.kx/self.ky)**0.5
         beta = ( (a/b) * np.cos(phi)**2 + (b/a) * np.sin(phi)**2 ) ** 0.5
         gamma = ( np.cos(theta)**2 +  ( (a**2/c**2) *np.cos(phi)**2 + (b**2/c**2) * np.sin(phi)**2 ) * np.sin(theta)**2 ) **0.5
-        rweff = 0.5 * (rw / alfa **(1.0/3.0)) *(1/beta) * np.sqrt ((1+ beta**2/gamma)**2 + ( (delta-1/delta) * (np.cos(theta)*np.cos(phi)*np.sin(phi)/gamma) )**2)
         rweff = 0.5 * rw / alfa ** (1.0 / 3.0) * (1 / beta) * np.sqrt((1 + (beta ** 2 / gamma)) ** 2  + ((delta - 1 / delta) * np.cos(theta) * np.cos(phi) * np.sin(phi) / gamma) ** 2)
         return rweff
 
@@ -320,7 +321,7 @@ class WiTNO:
                                 for jcontrol in range(self.ncontrol):
                                     value = I_0
                                     if (n > 0):
-                                        value = self.get_Infast(jcontrol, a, b, c, s1, s2, I_0)
+                                        value = self._get_Infast(jcontrol, a, b, c, s1, s2, I_0)
                                     ii = iseg * self.ncontrol + jcontrol
                                     m[kk][ii] += self.bfac[kseg] * L * value
 
@@ -333,10 +334,9 @@ class WiTNO:
                                         m[ii][self.M - 1] = -1
                                         brhs[ii] = 0
 
-        minv = np.linalg.inv(m)
         if (doprint):
             print(' dp ', brhs)
-        res = np.dot(minv, brhs)
+        res = np.linalg.solve(m, brhs)
         if (doprint):
             print('correct input ', np.dot(m, res))
 
@@ -472,10 +472,9 @@ class WiTNO:
                                 m[ii][self.M - 1] = -1
                                 brhs[ii] = 0
 
-        minv = np.linalg.inv(m)
         if (verbose):
             print(' dp ', brhs)
-        res = np.dot(minv, brhs)
+        res = np.linalg.solve(m, brhs)
         if (verbose):
             print('correct input ', np.dot(m, res))
 
@@ -498,7 +497,6 @@ class WiTNO:
         self._scale(sinv)
 
         return res, injindex, prodindex
-
 
 
 


### PR DESCRIPTION
Thank you for maintaining pyfastwell! This small PR focuses solely on improving numerical stability and preventing a minor method-name issue in the AEM solver (WiTNO). I kept the scope deliberately small and avoided any behavioral or API changes.
  - Summary of changes:
      - Switched from inv(m) @ brhs to np.linalg.solve(m, brhs) for better stability and performance.
      - Fixed a method call to _get_Infast, which prevents an AttributeError if higher-order modes are used (n > 0).
      - Added explicit numpy/pandas imports to avoid relying on wildcard imports.
      - Removed a duplicate assignment that was immediately overwritten.
  - Tests and examples still pass locally. If you prefer any of these changes to be split further or revised, I’m happy to adjust. Thanks for your time and consideration!

Changes (wi_tno.py only)

  - Use np.linalg.solve instead of matrix inverse:
      - src/pyfastwell/wellflow/wi_tno.py:339, 477
      - Rationale: solve is numerically more stable and faster than computing inv(m) @ brhs. No behavior change; improved stability.
  - Correct method call name for higher-order mode support:
      - src/pyfastwell/wellflow/wi_tno.py:324
      - Rationale: setupmatrix called get_Infast, but the method is defined as _get_Infast. Using the correct name prevents an AttributeError when n > 0. Matches existing usage in setupmatrix_new.
  - Add explicit imports:
      - src/pyfastwell/wellflow/wi_tno.py:3–4
      - Rationale: The module uses np and pd. Adding import numpy as np and import pandas as pd avoids reliance on wildcard imports leaking symbols.
  - Remove duplicate assignment:
      - src/pyfastwell/wellflow/wi_tno.py:165
      - Rationale: rweff was computed twice in a row; first value was immediately overwritten. Keeping a single, intended expression clarifies code without changing results.

Validation

  - Full test suite passes locally:
      - cd tests && MPLBACKEND=Agg uv run --no-project python -m unittest -v
      - 16 tests passed; no regressions.
