### PR TITLE
Fix link in docs to PyFastWell repository

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: pyfastwell
-repo_url: https://github.com/your-org/geothermal-npv-calc
+repo_url: https://github.com/TNO/pyfastwell
 theme:
   name: material
   logo: logo/logo_pyfastwell.png


### PR DESCRIPTION
The current link in the DOCS to the PyFastWell repository is broken and still references a placeholder URL. This PR links to the correct repository.